### PR TITLE
refactor: remove redundant rspack config

### DIFF
--- a/js/rspack.config.js
+++ b/js/rspack.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@rspack/cli').Configuration}
+ */
 module.exports = {
     context: __dirname,
     entry: {
@@ -5,10 +8,6 @@ module.exports = {
     },
     module: {
       rules: [
-        {
-          test: /\.css$/,
-          type: 'css'
-        },
         {
           test: /\.module.css$/,
           type: 'css/module'
@@ -32,7 +31,6 @@ module.exports = {
       ]
     },
     builtins: {
-      minify: false,
       html: [{
         template: './index.html'
       }],

--- a/ts/rspack.config.js
+++ b/ts/rspack.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@rspack/cli').Configuration}
+ */
 module.exports = {
     context: __dirname,
     entry: {
@@ -5,10 +8,6 @@ module.exports = {
     },
     module: {
       rules: [
-        {
-          test: /\.css$/,
-          type: 'css'
-        },
         {
           test: /\.module.css$/,
           type: 'css/module'
@@ -33,12 +32,8 @@ module.exports = {
       ]
     },
     builtins: {
-      minify: false,
       html: [{
         template: './index.html'
       }],
-      react: {
-        importSource: 'solid-js'
-      }
     }
   }


### PR DESCRIPTION
# Motivation 

## Removing `css` rule

Css module is included by Rspack by default, just remove it:

```
  {
      test: /\.css$/,
      type: 'css'
  }
```

CSS module rule is designed to be included, but there's an issue for it so we temporarily keep it. cc @hardfist

## Removing `builtins.react`

We don't need config `builtins.react` since we've configured `.jsx` transpliation behavior via `module.rules`:

```js
{
    test: /\.jsx$/,
    use: [
      {
        loader: 'babel-loader',
        options: {
          presets: [
            ["solid"]
          ],
          plugins: [
            "solid-refresh/babel"
          ]
        }
      }
    ]
}
```

So the code accepted by SWC is not JSX anymore.


## Removing `minify`

hard-code `minify: false` is for assets testing under `build`, we can just remove it.


// cc @h-a-n-a @bvanjoi @hardfist